### PR TITLE
use ToLowerInvariant() for mix-culture

### DIFF
--- a/ChilkatApi/AppData.cs
+++ b/ChilkatApi/AppData.cs
@@ -17,7 +17,7 @@ namespace ChilkatApi
         static public string GetAppData(string relativePath)
             {
             string url = "http://chilkatdownload.com/" + relativePath;
-            url = url.ToLower();
+            url = url.ToLowerInvariant();
             string txt = (string) m_cache[url];
             if (txt != null) return txt;
 


### PR DESCRIPTION
When using ToLower() "I"'s converted to little "I" which is turkish variant "ı" instead of "i". This change allows to lowercase properly on mixed-culture systems.